### PR TITLE
fix: add authentication, allowlist and input validation to /suggest endpoint

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
@@ -8,6 +8,7 @@
 package org.dspace.discovery;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -43,6 +44,22 @@ public class SolrSuggestService {
     }
 
     /**
+     * Check whether the given dictionary name is in the configured allowlist.
+     * If no allowlist is configured, all dictionaries are allowed.
+     *
+     * @param dictionary the dictionary name to check
+     * @return true if allowed, false otherwise
+     */
+    public boolean isAllowedDictionary(String dictionary) {
+        String[] allowed = configurationService.getArrayProperty(
+                "discovery.suggest.allowed-dictionaries");
+        if (allowed == null || allowed.length == 0) {
+            return true;
+        }
+        return Arrays.asList(allowed).contains(dictionary);
+    }
+
+    /**
      * Get a list of suggested terms from the Solr suggest request handler
      *
      * @param query      the current text input
@@ -69,8 +86,5 @@ public class SolrSuggestService {
             throw new RuntimeException("Unable to retrieve suggest response.", e);
         }
     }
-
-
-
 
 }

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -207,3 +207,6 @@ assetstore.jcloud.basedir = target/testing/dspace
 webui.submit.upload.required = true
 rest.cors.allowed-origins = http://localhost:4000
 dspace.name = DSpace at My University
+
+##### SUGGEST / AUTOCOMPLETE #####
+discovery.suggest.allowed-dictionaries = subject, authors, countries_file

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -35,12 +35,14 @@ import org.dspace.app.rest.parameter.SearchFilter;
 import org.dspace.app.rest.repository.DiscoveryRestRepository;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.discovery.SolrSuggestService;
-import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.RepresentationModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -72,6 +74,9 @@ public class DiscoveryRestController implements InitializingBean {
 
     @Autowired
     private ConverterService converter;
+
+    @Autowired
+    private SolrSuggestService solrSuggestService;
 
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -237,18 +242,36 @@ public class DiscoveryRestController implements InitializingBean {
     }
 
     /**
-     * Return serialized map of Solr search suggest handler results
-     * for use in autocomplete and term suggestion lookups
-     * @param dictionary dictionary as configured in search/solrconfig.xml
-     * @param query term query
-     * @return Map (to be serialized to JSON)
+     * Endpoint for autocomplete suggestions. Queries the Solr suggest handler.
+     * Protected by a configurable dictionary allowlist and authentication.
+     *
+     * @param dictionary the name of the suggest dictionary to query
+     * @param query      the current text input for autocomplete
+     * @return ResponseEntity with suggestion results in Solr suggest response format
      */
-    @RequestMapping(method = RequestMethod.GET, value = "/suggest", produces = "application/json")
-    public Map<String, Object> suggest(
-        @RequestParam(name = "dict") String dictionary,
-        @RequestParam(name = "q") String query) {
-        SolrSuggestService solrSuggestService = DSpaceServicesFactory.getInstance().getServiceManager()
-            .getServicesByType(SolrSuggestService.class).get(0);
-        return solrSuggestService.getSuggestions(query, dictionary);
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    @RequestMapping(method = RequestMethod.GET, value = "/suggest",
+            produces = "application/json")
+    public ResponseEntity<Map<String, Object>> suggest(
+            @RequestParam(name = "dict") String dictionary,
+            @RequestParam(name = "q") String query) {
+
+        if (StringUtils.isBlank(dictionary) || StringUtils.isBlank(query)) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        if (!solrSuggestService.isAllowedDictionary(dictionary)) {
+            log.warn("Suggest request for non-allowed dictionary: {}", dictionary);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> suggestions = solrSuggestService.getSuggestions(query, dictionary);
+            return ResponseEntity.ok(suggestions);
+        } catch (RuntimeException e) {
+            log.error("Error retrieving suggestions for dictionary={}, query={}", dictionary, query, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
@@ -110,4 +110,49 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
                 .andExpect(jsonPath("$.suggest.subject.test.numFound", is(0)));
     }
 
+    /**
+     * Test that an unauthenticated request returns HTTP 401 Unauthorized.
+     */
+    @Test
+    public void unauthenticatedRequestShouldReturn401() throws Exception {
+        getClient().perform(
+                get("/api/discover/suggest")
+                        .param("dict", "subject")
+                        .param("q", "test"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /**
+     * Test that a non-allowed dictionary request returns HTTP 403 Forbidden.
+     */
+    @Test
+    public void nonAllowedDictionaryShouldReturn403() throws Exception {
+        String userToken = getAuthToken(eperson.getEmail(), password);
+
+        getClient(userToken).perform(
+                get("/api/discover/suggest")
+                        .param("dict", "not_in_allowlist")
+                        .param("q", "test"))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Test that missing required parameters return HTTP 400 Bad Request.
+     */
+    @Test
+    public void missingParametersShouldReturn400() throws Exception {
+        String userToken = getAuthToken(eperson.getEmail(), password);
+
+        // Missing 'q' parameter
+        getClient(userToken).perform(
+                get("/api/discover/suggest")
+                        .param("dict", "subject"))
+                .andExpect(status().isBadRequest());
+
+        // Missing 'dict' parameter
+        getClient(userToken).perform(
+                get("/api/discover/suggest")
+                        .param("q", "test"))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -73,3 +73,7 @@ discovery.highlights.escape-html = true
 # in submission-forms.xml
 discovery.suggest.field = dc.contributor.author
 discovery.suggest.field = dc.subject
+
+# Allowlist of dictionary names that the /suggest endpoint will accept.
+# If empty, all dictionaries are allowed. Separate multiple values with commas.
+discovery.suggest.allowed-dictionaries = subject, authors, countries_file


### PR DESCRIPTION
## Summary

Adds authentication, authorization (dictionary allowlist), input validation, error handling and integration tests to the `/api/discover/suggest` endpoint.

---

## Changes

### 1. Authentication — `@PreAuthorize("hasAuthority('AUTHENTICATED')")`

**Issue:** The endpoint is publicly accessible without login.

**Reproduce:**
```
curl https://dspace.example.com/server/api/discover/suggest?dict=subject&q=test
```
Returns 200 with results — anyone on the internet can query Solr suggest without authentication.

**Risk:** Bots can scrape suggest data or DoS the endpoint (suggest queries build in-memory data structures and can be expensive). Most other DSpace REST endpoints require authentication.

**Fix:** Added `@PreAuthorize` — unauthenticated requests now return **401**.

---

### 2. Dictionary allowlist — `discovery.suggest.allowed-dictionaries`

**Issue:** The `dict` parameter is passed directly to Solr without any filtering.

**Reproduce:**
```
curl -H "Authorization: Bearer <token>" \
  "https://dspace.example.com/server/api/discover/suggest?dict=ANYTHING&q=test"
```
Solr receives `suggest.dictionary=NONEXISTENT` and returns an error response
that may include internal details (Java class names, Solr version, file paths).
Even for valid dictionaries, an allowlist limits the attack surface and follows
the principle of least privilege — only explicitly configured dictionaries are queryable.

**Fix:** Configurable allowlist in `discovery.cfg`:
```properties
discovery.suggest.allowed-dictionaries = subject, authors, countries_file
```
Non-allowed dictionaries return **403**. If the property is empty, all dictionaries are allowed (backward compatible).

---

### 3. Input validation — blank parameters → 400

**Issue:** Empty or blank `q` or `dict` parameters are forwarded to Solr.

**Reproduce:**
```
curl -H "Authorization: Bearer <token>" \
  "https://dspace.example.com/server/api/discover/suggest?dict=subject&q="
```
Sends `suggest.q=` to Solr — behavior is unpredictable depending on Solr version and dictionary type.

**Fix:** Blank parameters return **400 Bad Request** immediately.

---

### 4. Error handling — catch exceptions → 500

**Issue:** If Solr is unavailable or the dictionary isn't built, `SolrServerException` propagates as an unhandled `RuntimeException`, potentially exposing stack traces in the response.

**Fix:** Controller catches `RuntimeException`, logs the error server-side, and returns a clean **500** without stack trace.

---

### 5. Integration tests

3 new tests added (original 2 tests preserved):
- `unauthenticatedRequestShouldReturn401()` — no token → 401
- `nonAllowedDictionaryShouldReturn403()` — non-allowed dict → 403
- `missingParametersShouldReturn400()` — blank params → 400

---

## Files changed (5)

| File | Change |
|------|--------|
| `SolrSuggestService.java` | Added `isAllowedDictionary()` method |
| `DiscoveryRestController.java` | Added `@PreAuthorize`, validation, allowlist check, error handling, `@Autowired SolrSuggestService` |
| `AutocompleteSuggestionIT.java` | Added 3 new tests (original 2 preserved) |
| `discovery.cfg` | Added `discovery.suggest.allowed-dictionaries` config |
| `local.cfg` (test) | Added test allowlist config |
