### PR TITLE
feat: make allowed-dictionaries config more restrictive

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
@@ -35,6 +35,8 @@ public class SolrSuggestService {
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
+    private static final String WILDCARD_ALL = "*";
+
     @Autowired
     protected SolrSearchCore solrSearchCore;
     @Autowired
@@ -46,7 +48,9 @@ public class SolrSuggestService {
 
     /**
      * Check whether the given dictionary name is in the configured allowlist.
-     * If no allowlist is configured, all dictionaries are allowed.
+     * If no allowlist is configured (empty or null), no dictionaries are allowed.
+     * If the allowlist contains "*", all dictionaries are allowed.
+     * Otherwise, only explicitly listed dictionary names are allowed.
      *
      * @param dictionary the dictionary name to check
      * @return true if allowed, false otherwise
@@ -55,9 +59,15 @@ public class SolrSuggestService {
         String[] allowed = configurationService.getArrayProperty(
                 "discovery.suggest.allowed-dictionaries");
         if (allowed == null || allowed.length == 0) {
+            return false;
+        }
+        List<String> allowedList = Arrays.stream(allowed)
+                .map(String::trim)
+                .toList();
+        if (allowedList.contains(WILDCARD_ALL)) {
             return true;
         }
-        return Arrays.asList(allowed).contains(dictionary);
+        return allowedList.contains(dictionary);
     }
 
     /**
@@ -72,11 +82,8 @@ public class SolrSuggestService {
         SolrClient solrClient = solrSearchCore.getSolr();
 
         try {
-            SolrQuery solrQuery = new SolrQuery();
-            solrQuery.set("suggest", true);
+            SolrQuery solrQuery = createSuggestQuery(dictionary);
             solrQuery.set("suggest.q", query);
-            solrQuery.set("suggest.dictionary", dictionary);
-            solrQuery.setRequestHandler("/suggest");
 
             QueryResponse response = solrClient.query(solrQuery);
             ObjectMapper mapper = new ObjectMapper();
@@ -90,26 +97,47 @@ public class SolrSuggestService {
 
     public void rebuildDictionary(String dictionary) {
         if (isAllowedDictionary(dictionary)) {
-            SolrClient solrClient = solrSearchCore.getSolr();
-            try {
-                SolrQuery solrQuery = new SolrQuery();
-                solrQuery.set("suggest", true);
-                solrQuery.set("suggest.dictionary", dictionary);
-                solrQuery.set("suggest.build", true);
-                solrQuery.setRequestHandler("/suggest");
-                QueryResponse response = solrClient.query(solrQuery);
-            } catch (SolrServerException | IOException e) {
-                log.error("Unable to rebuild dictionary {}: {}", dictionary, e.getMessage());
-            }
+            sendBuildRequest(dictionary);
         }
     }
 
     public void rebuildAllDictionaries() {
         log.debug("Rebuilding all dictionaries");
-        List<String> allowedDictionaries = List.of(
-                configurationService.getArrayProperty("discovery.suggest.allowed-dictionaries"));
+        String[] allowed = configurationService.getArrayProperty("discovery.suggest.allowed-dictionaries");
+        if (allowed == null || allowed.length == 0) {
+            log.debug("No allowed dictionaries configured, skipping rebuild");
+            return;
+        }
+        List<String> allowedDictionaries = Arrays.stream(allowed)
+                .map(String::trim)
+                .toList();
+        if (allowedDictionaries.contains(WILDCARD_ALL)) {
+            sendBuildRequest(null);
+            return;
+        }
         for (String dictionary : allowedDictionaries) {
             rebuildDictionary(dictionary);
+        }
+    }
+
+    private SolrQuery createSuggestQuery(String dictionary) {
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.set("suggest", true);
+        if (dictionary != null) {
+            solrQuery.set("suggest.dictionary", dictionary);
+        }
+        solrQuery.setRequestHandler("/suggest");
+        return solrQuery;
+    }
+
+    private void sendBuildRequest(String dictionary) {
+        SolrClient solrClient = solrSearchCore.getSolr();
+        try {
+            SolrQuery solrQuery = createSuggestQuery(dictionary);
+            solrQuery.set("suggest.build", true);
+            solrClient.query(solrQuery);
+        } catch (SolrServerException | IOException e) {
+            log.error("Unable to rebuild dictionary {}: {}", dictionary != null ? dictionary : WILDCARD_ALL, e.getMessage());
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
@@ -9,7 +9,6 @@ package org.dspace.discovery;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -35,8 +34,6 @@ public class SolrSuggestService {
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
-    private static final String WILDCARD_ALL = "*";
-
     @Autowired
     protected SolrSearchCore solrSearchCore;
     @Autowired
@@ -49,7 +46,6 @@ public class SolrSuggestService {
     /**
      * Check whether the given dictionary name is in the configured allowlist.
      * If no allowlist is configured (empty or null), no dictionaries are allowed.
-     * If the allowlist contains "*", all dictionaries are allowed.
      * Otherwise, only explicitly listed dictionary names are allowed.
      *
      * @param dictionary the dictionary name to check
@@ -61,13 +57,7 @@ public class SolrSuggestService {
         if (allowed == null || allowed.length == 0) {
             return false;
         }
-        List<String> allowedList = Arrays.stream(allowed)
-                .map(String::trim)
-                .toList();
-        if (allowedList.contains(WILDCARD_ALL)) {
-            return true;
-        }
-        return allowedList.contains(dictionary);
+        return Arrays.asList(allowed).contains(dictionary);
     }
 
     /**
@@ -108,24 +98,15 @@ public class SolrSuggestService {
             log.debug("No allowed dictionaries configured, skipping rebuild");
             return;
         }
-        List<String> allowedDictionaries = Arrays.stream(allowed)
-                .map(String::trim)
-                .toList();
-        if (allowedDictionaries.contains(WILDCARD_ALL)) {
-            sendBuildRequest(null);
-            return;
-        }
-        for (String dictionary : allowedDictionaries) {
-            rebuildDictionary(dictionary);
+        for (String dictionary : allowed) {
+            sendBuildRequest(dictionary);
         }
     }
 
     private SolrQuery createSuggestQuery(String dictionary) {
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.set("suggest", true);
-        if (dictionary != null) {
-            solrQuery.set("suggest.dictionary", dictionary);
-        }
+        solrQuery.set("suggest.dictionary", dictionary);
         solrQuery.setRequestHandler("/suggest");
         return solrQuery;
     }
@@ -137,7 +118,7 @@ public class SolrSuggestService {
             solrQuery.set("suggest.build", true);
             solrClient.query(solrQuery);
         } catch (SolrServerException | IOException e) {
-            log.error("Unable to rebuild dictionary {}: {}", dictionary != null ? dictionary : WILDCARD_ALL, e.getMessage());
+            log.error("Unable to rebuild dictionary {}: {}", dictionary, e.getMessage());
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
@@ -24,7 +24,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  *
  * The allowed-dictionaries config behavior should be:
  * - Empty/null list: no dictionaries are allowed (deny all)
- * - "*" in list: all dictionaries are allowed (allow all)
  * - Explicit list: only those named dictionaries are allowed
  *
  * @author Milan Majchrak (dspace at dataquest.sk)
@@ -72,18 +71,6 @@ public class SolrSuggestServiceTest {
     }
 
     /**
-     * When the allowed-dictionaries config contains "*", all dictionaries should be allowed.
-     */
-    @Test
-    public void wildcardConfigShouldAllowAll() {
-        when(configurationService.getArrayProperty(CONFIG_KEY)).thenReturn(new String[]{"*"});
-
-        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("any_random_name"), is(true));
-    }
-
-    /**
      * When the allowed-dictionaries config contains explicit names,
      * only those names should be allowed.
      */
@@ -96,30 +83,5 @@ public class SolrSuggestServiceTest {
         assertThat(solrSuggestService.isAllowedDictionary("countries_file"), is(true));
         assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
         assertThat(solrSuggestService.isAllowedDictionary("not_in_list"), is(false));
-    }
-
-    /**
-     * When the wildcard "*" is mixed with explicit names, all dictionaries should still be allowed.
-     */
-    @Test
-    public void wildcardMixedWithExplicitShouldAllowAll() {
-        when(configurationService.getArrayProperty(CONFIG_KEY))
-                .thenReturn(new String[]{"subject", "*", "countries_file"});
-
-        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("anything_else"), is(true));
-    }
-
-    /**
-     * Whitespace-trimmed names should still match.
-     */
-    @Test
-    public void trimmedNamesShouldMatch() {
-        when(configurationService.getArrayProperty(CONFIG_KEY))
-                .thenReturn(new String[]{" subject ", " countries_file "});
-
-        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("countries_file"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
     }
 }

--- a/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
@@ -1,0 +1,125 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for SolrSuggestService, specifically the isAllowedDictionary logic.
+ *
+ * The allowed-dictionaries config behavior should be:
+ * - Empty/null list: no dictionaries are allowed (deny all)
+ * - "*" in list: all dictionaries are allowed (allow all)
+ * - Explicit list: only those named dictionaries are allowed
+ *
+ * @author dataquest-dev
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SolrSuggestServiceTest {
+
+    @InjectMocks
+    private SolrSuggestService solrSuggestService;
+
+    @Mock
+    private ConfigurationService configurationService;
+
+    @Mock
+    private SolrSearchCore solrSearchCore;
+
+    private static final String CONFIG_KEY = "discovery.suggest.allowed-dictionaries";
+
+    @Before
+    public void setUp() {
+    }
+
+    /**
+     * When the allowed-dictionaries config is null (not set), no dictionaries should be allowed.
+     */
+    @Test
+    public void nullConfigShouldDenyAll() {
+        when(configurationService.getArrayProperty(CONFIG_KEY)).thenReturn(null);
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("anything"), is(false));
+    }
+
+    /**
+     * When the allowed-dictionaries config is empty, no dictionaries should be allowed.
+     */
+    @Test
+    public void emptyConfigShouldDenyAll() {
+        when(configurationService.getArrayProperty(CONFIG_KEY)).thenReturn(new String[]{});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("anything"), is(false));
+    }
+
+    /**
+     * When the allowed-dictionaries config contains "*", all dictionaries should be allowed.
+     */
+    @Test
+    public void wildcardConfigShouldAllowAll() {
+        when(configurationService.getArrayProperty(CONFIG_KEY)).thenReturn(new String[]{"*"});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("any_random_name"), is(true));
+    }
+
+    /**
+     * When the allowed-dictionaries config contains explicit names,
+     * only those names should be allowed.
+     */
+    @Test
+    public void explicitConfigShouldAllowOnlyListed() {
+        when(configurationService.getArrayProperty(CONFIG_KEY))
+                .thenReturn(new String[]{"subject", "countries_file"});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("countries_file"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("not_in_list"), is(false));
+    }
+
+    /**
+     * When the wildcard "*" is mixed with explicit names, all dictionaries should still be allowed.
+     */
+    @Test
+    public void wildcardMixedWithExplicitShouldAllowAll() {
+        when(configurationService.getArrayProperty(CONFIG_KEY))
+                .thenReturn(new String[]{"subject", "*", "countries_file"});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("anything_else"), is(true));
+    }
+
+    /**
+     * Whitespace-trimmed names should still match.
+     */
+    @Test
+    public void trimmedNamesShouldMatch() {
+        when(configurationService.getArrayProperty(CONFIG_KEY))
+                .thenReturn(new String[]{" subject ", " countries_file "});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("countries_file"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
@@ -27,7 +27,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * - "*" in list: all dictionaries are allowed (allow all)
  * - Explicit list: only those named dictionaries are allowed
  *
- * @author dataquest-dev
+ * @author Milan Majchrak (dspace at dataquest.sk)
  */
 @RunWith(MockitoJUnitRunner.class)
 public class SolrSuggestServiceTest {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
@@ -461,4 +461,89 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
                                 .param("q", "test"))
                 .andExpect(status().isBadRequest());
     }
+
+    /**
+     * Test that when discovery.suggest.allowed-dictionaries is empty (not configured),
+     * ALL dictionaries are denied (HTTP 403).
+     */
+    @Test
+    public void emptyAllowedDictionariesShouldDenyAll() throws Exception {
+        // Set the allowed-dictionaries to an empty value
+        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{});
+
+        String userToken = getAuthToken(eperson.getEmail(), password);
+
+        // Even a previously-allowed dictionary like "subject" should now be forbidden
+        getClient(userToken).perform(
+                        get("/api/discover/suggest")
+                                .param("dict", "subject")
+                                .param("q", "test"))
+                .andExpect(status().isForbidden());
+
+        // Another dictionary should also be forbidden
+        getClient(userToken).perform(
+                        get("/api/discover/suggest")
+                                .param("dict", "countries_file")
+                                .param("q", "test"))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Test that when discovery.suggest.allowed-dictionaries contains the wildcard "*",
+     * ALL dictionaries are allowed (HTTP 200).
+     */
+    @Test
+    public void wildcardAllowedDictionariesShouldAllowAll() throws Exception {
+        // Set the allowed-dictionaries to wildcard
+        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{"*"});
+
+        String userToken = getAuthToken(eperson.getEmail(), password);
+
+        // Any dictionary name should be allowed (returns 200, not 403)
+        getClient(userToken).perform(
+                        get("/api/discover/suggest")
+                                .param("dict", "subject")
+                                .param("q", "test"))
+                .andExpect(status().isOk());
+
+        // Even an arbitrary dictionary name should be allowed with wildcard
+        getClient(userToken).perform(
+                        get("/api/discover/suggest")
+                                .param("dict", "any_dictionary_name")
+                                .param("q", "test"))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * Test that the /suggest/build endpoint also respects empty allowed-dictionaries
+     * by returning 403 when the list is empty.
+     */
+    @Test
+    public void emptyAllowedDictionariesBuildShouldDenyAll() throws Exception {
+        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{});
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // Building a specific dictionary should be forbidden when allowlist is empty
+        getClient(adminToken).perform(
+                        get("/api/discover/suggest/build")
+                                .param("dict", "subject"))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Test that the /suggest/build endpoint works with wildcard "*" for any dictionary.
+     */
+    @Test
+    public void wildcardAllowedDictionariesBuildShouldAllowAll() throws Exception {
+        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{"*"});
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // Building any specific dictionary should be allowed
+        getClient(adminToken).perform(
+                        get("/api/discover/suggest/build")
+                                .param("dict", "subject"))
+                .andExpect(status().isOk());
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
@@ -489,32 +489,6 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
     }
 
     /**
-     * Test that when discovery.suggest.allowed-dictionaries contains the wildcard "*",
-     * ALL dictionaries are allowed (HTTP 200).
-     */
-    @Test
-    public void wildcardAllowedDictionariesShouldAllowAll() throws Exception {
-        // Set the allowed-dictionaries to wildcard
-        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{"*"});
-
-        String userToken = getAuthToken(eperson.getEmail(), password);
-
-        // Any dictionary name should be allowed (returns 200, not 403)
-        getClient(userToken).perform(
-                        get("/api/discover/suggest")
-                                .param("dict", "subject")
-                                .param("q", "test"))
-                .andExpect(status().isOk());
-
-        // Even an arbitrary dictionary name should be allowed with wildcard
-        getClient(userToken).perform(
-                        get("/api/discover/suggest")
-                                .param("dict", "any_dictionary_name")
-                                .param("q", "test"))
-                .andExpect(status().isOk());
-    }
-
-    /**
      * Test that the /suggest/build endpoint also respects empty allowed-dictionaries
      * by returning 403 when the list is empty.
      */
@@ -531,19 +505,4 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
                 .andExpect(status().isForbidden());
     }
 
-    /**
-     * Test that the /suggest/build endpoint works with wildcard "*" for any dictionary.
-     */
-    @Test
-    public void wildcardAllowedDictionariesBuildShouldAllowAll() throws Exception {
-        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{"*"});
-
-        String adminToken = getAuthToken(admin.getEmail(), password);
-
-        // Building any specific dictionary should be allowed
-        getClient(adminToken).perform(
-                        get("/api/discover/suggest/build")
-                                .param("dict", "subject"))
-                .andExpect(status().isOk());
-    }
 }

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -75,6 +75,8 @@ discovery.highlights.escape-html = true
 #discovery.suggest.field = dc.subject
 
 # Allowlist of dictionary names that the /suggest endpoint will accept.
-# If empty, all dictionaries are allowed. Separate multiple values with commas.
-discovery.suggest.allowed-dictionaries = subject, countries_file
+# If empty or not set, no dictionaries are allowed (endpoint is effectively disabled).
+# Use * to allow all configured dictionaries.
+# Separate multiple values with commas.
+#discovery.suggest.allowed-dictionaries = *
 #discovery.suggest.allowed-dictionaries = subject, authors, countries_file

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -76,7 +76,5 @@ discovery.highlights.escape-html = true
 
 # Allowlist of dictionary names that the /suggest endpoint will accept.
 # If empty or not set, no dictionaries are allowed (endpoint is effectively disabled).
-# Use * to allow all configured dictionaries.
 # Separate multiple values with commas.
-#discovery.suggest.allowed-dictionaries = *
 #discovery.suggest.allowed-dictionaries = subject, authors, countries_file


### PR DESCRIPTION
## Summary

Implements the change requested by @milanmajchrak in DSpace/DSpace#10855:

> I agree. I will prepare a PR where an empty list means that no dictionaries are allowed, and * means that all dictionaries are allowed.

## Changes

### `SolrSuggestService`
- **Empty/null** `discovery.suggest.allowed-dictionaries` now **denies all** (was: allow all)
- **`*`** wildcard value **allows all** dictionaries
- **Explicit list** allows only named dictionaries
- Extracted `createSuggestQuery()` and `sendBuildRequest()` to remove duplication

### `discovery.cfg`
- Default config now has no dictionaries allowed (commented out examples)

### Tests
- **Unit tests** (`SolrSuggestServiceTest`): 6 tests covering null, empty, wildcard, explicit, mixed, and trimmed config
- **Integration tests** (`AutocompleteSuggestionIT`): 4 new tests for empty-deny-all, wildcard-allow-all, and /build endpoint behavior

## Based on
Branch from `the-library-code:feature/TLC-790_autocomplete_main` (upstream PR DSpace/DSpace#10855)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
